### PR TITLE
🔧 chore: GitHub Actions 워크플로우 추가 - 포크 자동 동기화

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,23 @@
+name: Sync Fork
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-fork:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+       
+      - name: Push to fork
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.FORK_TOKEN }}
+          repository: LeeCh0129/Rolling
+          branch: ${{ github.ref_name }}
+          force: false


### PR DESCRIPTION
## 📌 변경 사항 개요
Github Actions 워크플로우를 추가하여 팀 레포의 main 브랜치 변경 사항을 개인 포크 레포로 자동 동기화하는 기능 구현

## 📝 상세 내용
- 워크플로우 트리거 조건: main 브랜치에 push 발생 시 작동하도록 `push: branches: -main`으로 설정
- 개인 레포(LeeCh0129/Rolling)로 변경사항 자동 동기화 설정
- 팀 레포지토리에 `FORK_TOKEN` 시크릿 설정을 추가

## 🔗 관련 이슈

Rolling [#11](https://github.com/codeit-maso/Rolling/issues/11)

## 🖼️ 스크린샷

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
- 워크플로우는 팀 레포지토리의 main 브랜치 변경 사항을 개인 포크 레포지토리로 자동 동기화하여 Vercel에서 개인 계정으로 무료 배포하기 위함(Vercel에서 팀 레포지토리 배포는 유료이기에 개인 레포로 포크한뒤 사용)
