### PR TITLE
🔧 chore: 워크플로우 트리거에 develop 브랜치 추가-테스트용

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
 
 jobs:
   sync-fork:


### PR DESCRIPTION
## 📌 변경 사항 개요
- GitHub Actions 워크플로우 트리거 조건에 develop 브랜치를 추가하여 develop 브랜치에서 워크플로우 기능을 안전하게 테스트할 수 있도록 `develop` 추가

## 📝 상세 내용
- 파일의 트리거 조건에 develop 브랜치를 추가하여 develop 브랜치에 푸시할 때도 워크플로우가 실행되도록 함.
- 기존의 main 브랜치에 영향 없이 워크플로우 기능 테스트 하기 위함.

## 🔗 관련 이슈
Rolling #11 
<!-- 관련된 이슈 번호 (예: Resolves: #123) -->

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
