### PR TITLE
🔧 chore: 워크플로우에 contents 쓰기 권한 추가

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -6,6 +6,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: write
+
 jobs:
   sync-fork:
     runs-on: ubuntu-latest
@@ -21,4 +24,3 @@ jobs:
           github_token: ${{ secrets.FORK_TOKEN }}
           repository: LeeCh0129/Rolling
           branch: ${{ github.ref_name }}
-          force: false


### PR DESCRIPTION
## 📌 변경 사항 개요
GIthub Actions 워크플로우에 쓰기 권한을 추가

## 📝 상세 내용
- Actions에서 Push to fork 도중 The requested URL returned error: 403
- `permssions: contents: write`를 추가하여 워크플로우가 포크 레포지토리에 푸시할 수 있는 권한을 갖도록 함.

## 🔗 관련 이슈
#11 

## 🖼️ 스크린샷

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
https://github.com/orgs/community/discussions/57244
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions