### PR TITLE
🔧 chore: 워크플로우 추가하여 개인 포크 자동 동기화 구현 - SSH 키 인증 대체

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -5,9 +5,7 @@ on:
     branches:
       - main
       - develop
-
-permissions:
-  contents: write
+  workflow_dispatch:
 
 jobs:
   sync-fork:
@@ -17,10 +15,16 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-       
-      - name: Push to fork
-        uses: ad-m/github-push-action@master
+          
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.8.0
         with:
-          github_token: ${{ secrets.FORK_TOKEN }}
-          repository: LeeCh0129/Rolling
-          branch: ${{ github.ref_name }}
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          
+      - name: Add known hosts
+        run: ssh-keyscan github.com >> ~/.ssh/known_hosts
+          
+      - name: Push to fork
+        run: |
+          git remote add fork git@github.com:LeeCh0129/Rolling.git
+          git push fork ${GITHUB_REF#refs/heads/}


### PR DESCRIPTION
## 📌 변경 사항 개요
- GitHub Actions 워크플로우로 팀 레포지토리와 개인 포크 레포지토리 간 자동 동기화 기능
- webfactory/ssh-agent 액션을 사용하여 SSH 인증 방식으로 코드를 푸시

## 📝 상세 내용
- main 또는 develop 브랜치에서 푸시 발생 시 자동으로 워크플로우가 실행되어 코드를 동기화
- 기존의 PAT가 아닌 SSH 키 인증 방식으로 변경

## 🔗 관련 이슈
Rolling #26 

## 🖼️ 스크린샷

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
- 개인 포크 레포지토리에는 SSH 공개키가 배포키로 설정, 쓰기 권한 활성화
