### PR TITLE
🐛 fix: 팀ID 환경변수 적용 및 Vercel 배포 라우팅 설정 추가

### DIFF
--- a/src/api/getRecipients.js
+++ b/src/api/getRecipients.js
@@ -1,6 +1,7 @@
 import { api } from './api';
 
 export default async function getRecipients() {
-  const res = await api.get('/13-5/recipients/');
+  const teamId = import.meta.env.VITE_TEAM_ID;
+  const res = await api.get(`/${teamId}/recipients/`);
   return res.data;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## 📌 변경 사항 개요

Vercel 배포 환경에서 발생하는 404 오류를 해결하기 위해 API 요청의 팀 ID를 환경변수로 변경하고, 라우팅을 위한 vercel.json 설정을 추가했습니다.

## 📝 상세 내용

- [x] getRecipients 함수에서 하드코딩된 팀 ID('13-5')를 환경변수(VITE_TEAM_ID, '15-7')로 변경
- [x] 라우팅을 위한 vercel.json 파일 추가 - 모든 라우팅 요청을 index.html로 리다이렉트

## 🔗 관련 이슈

#56 #57 

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
- 환경변수는 이미 Vercel에 설정되어 있으며, 코드만 수정