### PR TITLE
🎨 style: edit 페이지 분리 / 애니메이션 추가 / 뒤로가기 버튼 추가 / 스켈레톤 ui 적용

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,11 @@ export default function App() {
         <Route path="/" element={<Home />} />
         <Route path="/list" element={<RecipientList />} />
         <Route path="/post" element={<CreateRecipient />} />
-        <Route path="/post/:id" element={<Recipient />} />
+        <Route path="/post/:id" element={<Recipient showDelete={false} />} />
+        <Route
+          path="/post/:id/edit"
+          element={<Recipient showDelete={true} />}
+        />
         <Route path="/post/:id/message" element={<MessageForm />} />
       </Routes>
     </>

--- a/src/assets/styles/base.scss
+++ b/src/assets/styles/base.scss
@@ -27,11 +27,6 @@ html {
   font-size: 62.5%;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
 button {
   cursor: pointer;
 }

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -42,11 +42,11 @@ export default function Card({
 
   return (
     <article
-      className={`${styles.card} ${empty ? styles['card--empty'] : ''}`}
-      onClick={() => !empty && onClick?.(id)}
+      className={`${styles.card} ${empty ? styles['card--empty'] : ''} ${showDelete ? styles['card--show'] : ''}`}
+      onClick={() => (empty ? clickPost() : onClick?.(id))}
     >
       {empty ? (
-        <div onClick={clickPost}>
+        <div>
           <img src={plus} alt="추가하기" />
         </div>
       ) : (

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -24,6 +24,7 @@ export default function Card({
   empty = false,
   onDelete,
   onClick,
+  showDelete,
 }) {
   const navigate = useNavigate();
   const sanitizedHTML = DOMPurify.sanitize(children);
@@ -64,11 +65,13 @@ export default function Card({
                 <Badge relation={relationship} />
               </div>
             </div>
-            <div className={styles['card__delete-button']}>
-              <button onClick={clickDelete}>
-                <img src={deleteIcon} alt="쓰레기통 아이콘" />
-              </button>
-            </div>
+            {showDelete && (
+              <div className={styles['card__delete-button']}>
+                <button onClick={clickDelete}>
+                  <img src={deleteIcon} alt="쓰레기통 아이콘" />
+                </button>
+              </div>
+            )}
           </header>
           <div className={styles['card__body']}>
             <div className={styles['card__content']}>

--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -10,6 +10,12 @@
   box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.08);
   background: $white;
   gap: 16px;
+  transition: transform 0.2s ease;
+  cursor: pointer;
+
+  &:hover {
+    transform: scale(0.95);
+  }
 
   &.card--empty {
     display: flex;
@@ -21,6 +27,10 @@
       height: 56px;
       cursor: pointer;
     }
+  }
+
+  &.card--show {
+    cursor: default;
   }
 
   &__header {
@@ -97,6 +107,18 @@
   &__footer {
     @include font-12-regular;
     color: $gray-400;
+  }
+}
+
+@keyframes click-pop {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.03); // 살짝 커졌다가
+  }
+  100% {
+    transform: scale(1); // 다시 원래대로
   }
 }
 

--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -101,6 +101,11 @@
       word-break: break-word;
       @include font-18-regular;
       color: $gray-600;
+      ul,
+      li,
+      a {
+        all: revert;
+      }
     }
   }
 

--- a/src/components/common/Button.module.scss
+++ b/src/components/common/Button.module.scss
@@ -30,7 +30,7 @@
     background-color: $purple-800;
   }
 
-  &:focus {
+  &:focus-visible {
     border: 2px solid $purple-900;
     background-color: $purple-800;
   }

--- a/src/components/layout/Header/Header.module.scss
+++ b/src/components/layout/Header/Header.module.scss
@@ -26,6 +26,8 @@
   border: 1px solid $gray-300;
   border-radius: 6px;
   white-space: nowrap;
+  color: inherit;
+  text-decoration: none;
 }
 
 @media (min-width: 361px) and (max-width: 768px) {

--- a/src/pages/CreateRecipient/CreateRecipient.jsx
+++ b/src/pages/CreateRecipient/CreateRecipient.jsx
@@ -16,6 +16,7 @@ export default function CreateRecipient() {
   const [selectedType, setSelectedType] = useState('color');
   const [selectedColor, setSelectedColor] = useState('beige');
   const [selectedImage, setSelectedImage] = useState(-1);
+  const [imageLoading, setImageLoading] = useState([]);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -23,6 +24,7 @@ export default function CreateRecipient() {
       try {
         const result = await getBackgroundImage();
         setData(result);
+        setImageLoading(new Array(result.length).fill(true));
       } catch (error) {
         console.error('데이터 로딩 실패:', error);
       }
@@ -49,6 +51,14 @@ export default function CreateRecipient() {
 
   function handleImageClick(index) {
     setSelectedImage(index);
+  }
+
+  function handleImageLoad(index) {
+    setImageLoading((prev) => {
+      const updated = [...prev];
+      updated[index] = false;
+      return updated;
+    });
   }
 
   async function handleButtonClick() {
@@ -113,6 +123,7 @@ export default function CreateRecipient() {
             이미지
           </button>
         </div>
+
         {selectedType === 'color' && (
           <ul className={styles['create-page__color-list']}>
             {colors.map((color) => (
@@ -149,10 +160,17 @@ export default function CreateRecipient() {
                 }`}
                 onClick={() => handleImageClick(index)}
               >
+                {imageLoading[index] && (
+                  <div className={styles['create-page__skeleton']} />
+                )}
                 <img
                   src={url}
                   alt={`배경이미지${index + 1}`}
-                  className={styles['create-page__background-img']}
+                  className={`
+                    ${styles['create-page__background-img']} 
+                    ${imageLoading[index] ? styles['create-page__background-img--hidden'] : ''}
+                  `}
+                  onLoad={() => handleImageLoad(index)}
                 />
                 {selectedImage === index && (
                   <img
@@ -176,7 +194,6 @@ export default function CreateRecipient() {
           생성하기
         </Button>
       </div>
-
     </div>
   );
 }

--- a/src/pages/CreateRecipient/CreateRecipient.module.scss
+++ b/src/pages/CreateRecipient/CreateRecipient.module.scss
@@ -64,6 +64,14 @@
       list-style: none;
       flex-shrink: 0;
       cursor: pointer;
+      transition:
+        transform 0.3s ease,
+        box-shadow 0.3s ease;
+
+      &:hover {
+        transform: scale(1.05);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      }
     }
 
     .create-page__color--selected {
@@ -111,6 +119,14 @@
       overflow: hidden;
       flex-shrink: 0;
       cursor: pointer;
+      transition:
+        transform 0.3s ease,
+        box-shadow 0.3s ease;
+
+      &:hover {
+        transform: scale(1.05);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      }
 
       .create-page__background-img {
         position: absolute;

--- a/src/pages/CreateRecipient/CreateRecipient.module.scss
+++ b/src/pages/CreateRecipient/CreateRecipient.module.scss
@@ -137,6 +137,30 @@
   }
 }
 
+.create-page__skeleton {
+  width: 100%;
+  height: 100%;
+  background-color: #e0e0e0;
+  animation: skeleton-loading 1.2s infinite ease-in-out;
+  border-radius: 8px;
+}
+
+@keyframes skeleton-loading {
+  0% {
+    background-color: #e0e0e0;
+  }
+  50% {
+    background-color: #f0f0f0;
+  }
+  100% {
+    background-color: #e0e0e0;
+  }
+}
+
+.create-page__background-img--hidden {
+  display: none;
+}
+
 @media (max-width: 1024px) {
   .create-page {
     position: relative;

--- a/src/pages/Recipient/Recipient.jsx
+++ b/src/pages/Recipient/Recipient.jsx
@@ -10,7 +10,7 @@ import Button from '../../components/common/Button';
 import Modal from '../../components/Modal/Modal.jsx';
 import styles from './Recipient.module.scss';
 
-export default function Recipient() {
+export default function Recipient({ showDelete }) {
   const { id } = useParams();
   const [postData, setPostData] = useState(null);
   const [messages, setMessages] = useState([]);
@@ -107,6 +107,14 @@ export default function Recipient() {
     }
   }
 
+  function handleGoBack() {
+    navigate(-1);
+  }
+
+  function handleEditClick(id) {
+    navigate(`/post/${id}/edit`);
+  }
+
   function handleOpenModal(id) {
     setSelectedCardId(id);
   }
@@ -134,13 +142,31 @@ export default function Recipient() {
         }
       >
         <div className={styles['button-container']}>
-          <Button
-            className={styles['delete-button']}
-            type="delete"
-            onClick={() => handleDeleteRecipient(id)}
-          >
-            삭제하기
-          </Button>
+          <div className={styles['back-button-wrapper']}>
+            <button className={styles['back-button']} onClick={handleGoBack}>
+              ← 뒤로가기
+            </button>
+          </div>
+
+          <div className={styles['action-button-wrapper']}>
+            {showDelete ? (
+              <Button
+                className={styles['delete-button']}
+                type="delete"
+                onClick={() => handleDeleteRecipient(id)}
+              >
+                삭제하기
+              </Button>
+            ) : (
+              <Button
+                className={styles['delete-button']}
+                type="delete"
+                onClick={() => handleEditClick(id)}
+              >
+                편집하기
+              </Button>
+            )}
+          </div>
         </div>
         <div className={styles['card-container']}>
           <Card recipientId={id} empty={true} />
@@ -156,6 +182,7 @@ export default function Recipient() {
               onDelete={handleDeleteMessage}
               onClick={() => handleOpenModal(msg.id)}
               font={msg.font}
+              showDelete={showDelete}
             >
               {msg.content}
             </Card>

--- a/src/pages/Recipient/Recipient.jsx
+++ b/src/pages/Recipient/Recipient.jsx
@@ -150,26 +150,20 @@ export default function Recipient({ showDelete }) {
 
           <div className={styles['action-button-wrapper']}>
             {showDelete ? (
-              <Button
-                className={styles['delete-button']}
-                type="delete"
-                onClick={() => handleDeleteRecipient(id)}
-              >
+              <Button type="delete" onClick={() => handleDeleteRecipient(id)}>
                 삭제하기
               </Button>
             ) : (
-              <Button
-                className={styles['delete-button']}
-                type="delete"
-                onClick={() => handleEditClick(id)}
-              >
+              <Button type="delete" onClick={() => handleEditClick(id)}>
                 편집하기
               </Button>
             )}
           </div>
         </div>
         <div className={styles['card-container']}>
-          <Card recipientId={id} empty={true} />
+          {!showDelete && (
+            <Card recipientId={id} empty={true} showDelete={showDelete} />
+          )}
           {messages.map((msg) => (
             <Card
               key={msg.id}

--- a/src/pages/Recipient/Recipient.jsx
+++ b/src/pages/Recipient/Recipient.jsx
@@ -151,7 +151,7 @@ export default function Recipient({ showDelete }) {
           <div className={styles['action-button-wrapper']}>
             {showDelete ? (
               <Button type="delete" onClick={() => handleDeleteRecipient(id)}>
-                삭제하기
+                페이지 삭제하기
               </Button>
             ) : (
               <Button type="delete" onClick={() => handleEditClick(id)}>

--- a/src/pages/Recipient/Recipient.jsx
+++ b/src/pages/Recipient/Recipient.jsx
@@ -134,9 +134,9 @@ export default function Recipient({ showDelete }) {
     <>
       <HeaderService recipient={postData} />
       <div
-        className={`${styles['post-container']} ${!postData.backgroundImageURL ? styles[`background--${postData.backgroundColor}`] : ''}`}
+        className={`${styles['post-container']} ${!postData.backgroundImageURL ? styles[`background--${postData.backgroundColor}`] : ''} ${showDelete ? styles[`background--gray`] : ''}`}
         style={
-          postData.backgroundImageURL
+          postData.backgroundImageURL && !showDelete
             ? { backgroundImage: `url(${postData.backgroundImageURL})` }
             : {}
         }

--- a/src/pages/Recipient/Recipient.module.scss
+++ b/src/pages/Recipient/Recipient.module.scss
@@ -32,6 +32,10 @@
   background-color: $purple-200;
 }
 
+.background--gray {
+  background-color: $gray-200;
+}
+
 .card-container {
   max-width: 1200px;
   margin: 0 auto;

--- a/src/pages/Recipient/Recipient.module.scss
+++ b/src/pages/Recipient/Recipient.module.scss
@@ -44,7 +44,40 @@
   max-width: 1200px;
   margin: 0 auto 11px;
   display: flex;
-  flex-direction: row-reverse;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.back-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: $white;
+  transition: transform 0.3s ease;
+  @include font-18-bold;
+
+  &:hover {
+    animation: shake 0.5s ease;
+    animation-iteration-count: 1;
+  }
+}
+
+@keyframes shake {
+  0% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-5px);
+  }
+  50% {
+    transform: translateX(5px);
+  }
+  75% {
+    transform: translateX(-5px);
+  }
+  100% {
+    transform: translateX(0);
+  }
 }
 
 @media (max-width: 1248px) {
@@ -67,9 +100,22 @@
 
   .button-container {
     width: calc(100% - 48px);
+    display: block;
+    position: relative;
+  }
+
+  .back-button-wrapper {
+    position: static;
+    margin-bottom: 11px;
+  }
+
+  .action-button-wrapper {
     position: fixed;
     bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
     z-index: 2;
+    width: calc(100% - 48px);
   }
 }
 


### PR DESCRIPTION
## 📌 변경 사항 개요

- 뒤로가기 버튼 추가
- edit 페이지 분리
- 애니메이션 추가
- 롤링페이퍼 만들기 페이지에 스켈레톤 ui 적용

## 📝 상세 내용

- 뒤로가기 버튼 추가
- edit 페이지와 기존 페이지를 분리
  - 기존 페이지에서는 삭제 버튼이 없음
  - 편집하기 버튼 클릭시 edit 페이지로 이동
  - edit 페이지에서는 메시지 삭제 및 페이지 삭제 가능
  - edit 페이지의 배경은 회색
- 애니메이션 추가
  - 메시지에 마우스 올리면 애니메이션 효과
  - 뒤로가기 버튼에 마우스 올리면 애니메이션 효과
  - 배경 색 및 이미지 선택 칸에 마우스 올리면 애니메이션 효과

## 🔗 관련 이슈

#79 #80 

## 🖼️ 스크린샷

![image](https://github.com/user-attachments/assets/429b88a8-95fc-4210-9c29-6e2508712087)

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
