### PR TITLE
🎨style: 버튼 및 유저 프로필 전환 효과 추가

### DIFF
--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -10,11 +10,11 @@
   box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.08);
   background: $white;
   gap: 16px;
-  transition: transform 0.2s ease;
+  transition: transform 0.2s ease-in-out;
   cursor: pointer;
 
   &:hover {
-    transform: scale(0.95);
+    transform: scale(0.95) translateZ(0);
   }
 
   &.card--empty {
@@ -117,13 +117,13 @@
 
 @keyframes click-pop {
   0% {
-    transform: scale(1);
+    transform: scale(1) translateZ(0);
   }
   50% {
-    transform: scale(1.03); // 살짝 커졌다가
+    transform: scale(1.03) translateZ(0); // 살짝 커졌다가
   }
   100% {
-    transform: scale(1); // 다시 원래대로
+    transform: scale(1) translateZ(0); // 다시 원래대로
   }
 }
 

--- a/src/components/UserProfileSelector/UserProfileSelector.module.scss
+++ b/src/components/UserProfileSelector/UserProfileSelector.module.scss
@@ -51,6 +51,20 @@
     width: 56px;
     border: 1px solid $gray-200;
     border-radius: 100px;
+    transition: transform 0.1s ease-in-out;
+
+    &:hover {
+      transform: scale(1.15) translateY(-6px) translateZ(0);
+    }
+
+    &:active {
+      transform: scale(1) translateY(0) translateZ(0);
+    }
+  }
+
+  &__image--selected {
+    transform: scale(1.2) translateY(-6px) translateZ(0);
+    box-shadow: 0 0 0 2px $gray-300;
   }
 
   @media (max-width: 767px) {

--- a/src/components/common/Button.module.scss
+++ b/src/components/common/Button.module.scss
@@ -9,24 +9,31 @@
   background-color: $purple-600;
   @include font-18-bold;
   color: $white;
+  transition:
+    transform 0.2s ease-in-out,
+    background-color 0.2s ease-in-out;
 
   &:disabled {
     background-color: $gray-300;
     cursor: not-allowed;
+    filter: opacity(50%);
 
     &:hover,
     &:active,
     &:focus {
       background-color: $gray-300;
       border: $gray-300;
+      transform: none;
     }
   }
 
   &:hover {
+    transform: scale(1.05) translateZ(0);
     background-color: $purple-700;
   }
 
   &:active {
+    transform: scale(0.97) translateZ(0);
     background-color: $purple-800;
   }
 

--- a/src/pages/CreateRecipient/CreateRecipient.jsx
+++ b/src/pages/CreateRecipient/CreateRecipient.jsx
@@ -81,7 +81,7 @@ export default function CreateRecipient() {
       <div className={styles['create-page__input-section']}>
         <FormInput
           label="To."
-          placeholder="받는 사람 이름을 입력해 주세요"
+          placeholder="받는 사람 이름을 입력해 주세요. (최대 10자)"
           value={value}
           onChange={handleInputChange}
           onBlur={handleBlur}

--- a/src/pages/CreateRecipient/CreateRecipient.module.scss
+++ b/src/pages/CreateRecipient/CreateRecipient.module.scss
@@ -65,8 +65,8 @@
       flex-shrink: 0;
       cursor: pointer;
       transition:
-        transform 0.3s ease,
-        box-shadow 0.3s ease;
+        transform 0.3s ease-in-out,
+        box-shadow 0.3s ease-in-out;
 
       &:hover {
         transform: scale(1.05);
@@ -124,7 +124,7 @@
         box-shadow 0.3s ease;
 
       &:hover {
-        transform: scale(1.05);
+        transform: scale(1.05) translateZ(0);
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
       }
 

--- a/src/pages/MessageForm/MessageForm.jsx
+++ b/src/pages/MessageForm/MessageForm.jsx
@@ -126,7 +126,7 @@ export default function MessageForm() {
         <div className={styles['message-form__input']}>
           <FormInput
             label="From."
-            placeholder="이름을 입력해 주세요 (10자 이내)"
+            placeholder="이름을 입력해 주세요. (최대 10자)"
             value={sender}
             onChange={handleInputChange}
             onBlur={handleSenderBlur}

--- a/src/pages/MessageForm/MessageForm.module.scss
+++ b/src/pages/MessageForm/MessageForm.module.scss
@@ -17,6 +17,7 @@
     & {
       display: flex;
       align-items: center;
+      max-width: 320px;
       gap: 206px;
     }
   }


### PR DESCRIPTION
## 📌 변경 사항 개요

버튼 및 유저 프로필 전환 효과 추가

## 📝 상세 내용

버튼 및 유저 프로필 클릭이나 호버 시 커지는 효과 구현
메세지 작성 페이지 모바일 사이즈 추가
인풋 입력 칸 텍스트 수정

## 🔗 관련 이슈

#78 

## 🖼️ 스크린샷

프로필 선택시 커짐 / 호버시 커짐
![image](https://github.com/user-attachments/assets/a368fc5f-c238-4039-ae05-549c7e72f098)
버튼 호버
![image](https://github.com/user-attachments/assets/9f6f33e7-8d29-4dd2-bd43-c33c31b210be)
버튼 클릭
![image](https://github.com/user-attachments/assets/abc98909-5fdc-4a81-9252-44c7cc286382)

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
